### PR TITLE
SecondaryKey

### DIFF
--- a/Test Script/Test-OMSDataInjection.ps1
+++ b/Test Script/Test-OMSDataInjection.ps1
@@ -6,6 +6,7 @@ $ISONow = "{0:yyyy-MM-ddThh:mm:ssZ}" -f $now
 #Change the OMSWorkspaceId
 $OMSWorkSpaceId = Read-Host -Prompt 'Enter the workspace Id'
 $PrimaryKey = Read-Host -Prompt 'Enter the primary key'
+$SecondaryKey = Read-Host -Prompt 'Enter the secondary key'
 
 #region Test PS object input
 $ObjProperties = @{


### PR DESCRIPTION
Script will fail with error that $Secondarykey is empty.
Either remove it from parameters, or prompt like I edited.
