### PR TITLE
Update error handling

### DIFF
--- a/OMSDataInjection/OMSDataInjection.psm1
+++ b/OMSDataInjection/OMSDataInjection.psm1
@@ -204,12 +204,12 @@ Function Publish-OMSData
     }
   } 
   
-  if ($response.StatusCode -eq 202)
+  if ($response.StatusCode -in 200,202)
   {
     Write-Verbose -Message 'OMS data injection accepted!'
     $InjectSuccessful = $true
   } else {
-    Write-Error $ErrorMessage
+    Write-Error "API returned status code [$($response.StatusCode)]"
     $InjectSuccessful = $false
   }
   $InjectSuccessful


### PR DESCRIPTION
Recently I've seen conditions where data was successfully posted to OMS but an error was returned by the Publish-OMSData function. OMS was returning a status code 200, rather than 202, and the code dropped into an else block that attempted to return an error. However, the $ErrorMessage variable is undefined here so a WriteErrorException was returned instead.

This fixes both the filtering for success codes and provides a message in case the status code is not a successful one. Please consider incorporating these changes.

Thanks!